### PR TITLE
Bump digest to version 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Nikolay Denev <ndenev@cisco.com>"]
 
 
 [dependencies]
-digest = "0.10"
+digest = "0.11"
 tokio = { version = "1", optional = true }
 pin-project = { version = "1.1" }
 
@@ -19,7 +19,7 @@ tokio = ["dep:tokio"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-sha2 = "0.10"
+sha2 = "0.11"
 criterion = { version = "0.5", features = [
     "html_reports",
     "async_tokio",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use hashing_reader::HashingReader;
 let data = "some data to hash";
 let reader = data.as_bytes();
 
-let (hr, rx) = HashingReader::<_, Sha256>::new(reader);
+let (mut hr, rx) = HashingReader::<_, Sha256>::new(reader);
 
 let mut buf = Vec::new();
 let _ = hr.read_to_end(&mut buf);


### PR DESCRIPTION
## Description

This PR contains two small maintenance changes:

- **Update `digest` and `sha2` dependencies to `0.11`** (`Cargo.toml`) to stay current with the latest upstream releases of the hashing crates used by `HashingReader`.
- **Mark `HashingReader` as mutable in the README usage example** so the snippet compiles cleanly when readers copy it into their own projects or when it is exercised via `cargo test` (doc-tests). Without `mut`, calling the reading APIs on `HashingReader` produces a compiler error because they require a mutable receiver.

No functional or API changes are introduced; this is purely a dependency bump and a documentation fix.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [x] Other (please describe): dependency version bump (`digest`, `sha2` → `0.11`)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
